### PR TITLE
Updated .gitignore to include patterns for service account keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ yarn-error.*
 # local env files
 .env*.local
 
+# service account keys
+*-service-account.json
+
 # typescript
 *.tsbuildinfo
 


### PR DESCRIPTION
This pattern will prevent any files ending with -service-account.json from being accidentally committed to the repository

[[]](https://github.com/lunarihq/lunari-app/issues/12)